### PR TITLE
Add More Standard Illuminants

### DIFF
--- a/src/photog/color_utils.cpp
+++ b/src/photog/color_utils.cpp
@@ -28,7 +28,17 @@ namespace photog {
     std::array<float, 3>
     get_tristimulus(PhotogIlluminant illuminant) {
         static std::map<PhotogIlluminant, std::array<float, 3>> tristimuli =
-                {{PhotogIlluminant::D65, {0.95047f, 1.0f, 1.08883f}}};
+                {{PhotogIlluminant::A,   {1.09850f, 1.0f, 0.35585f}},
+                 {PhotogIlluminant::B,   {0.99072f, 1.0f, 0.85223f}},
+                 {PhotogIlluminant::C,   {0.98074f, 1.0f, 1.18232f}},
+                 {PhotogIlluminant::D50, {0.96422f, 1.0f, 0.82521f}},
+                 {PhotogIlluminant::D55, {0.95682f, 1.0f, 0.92149f}},
+                 {PhotogIlluminant::D65, {0.95047f, 1.0f, 1.08883f}},
+                 {PhotogIlluminant::D75, {0.94972f, 1.0f, 1.22638f}},
+                 {PhotogIlluminant::E,   {1.0f,     1.0f, 1.0f}},
+                 {PhotogIlluminant::F2,  {0.99186f, 1.0f, 0.67393f}},
+                 {PhotogIlluminant::F7,  {0.95041f, 1.0f, 1.08747f}},
+                 {PhotogIlluminant::F11, {1.00962f, 1.0f, 0.64350f}}};
 
         return tristimuli.at(illuminant);
     }

--- a/src/photog/include/photog/color.h
+++ b/src/photog/include/photog/color.h
@@ -13,8 +13,32 @@ enum PhotogChromadaptMethod {
     Bradford
 };
 
+/** Standard illuminants of various vintages.
+ *
+ * References:
+ *  http://www.brucelindbloom.com/Eqn_ChromAdapt.html
+ *  https://en.wikipedia.org/wiki/Standard_illuminant
+ *  https://www.image-engineering.de/library/technotes/753-cie-standard-illuminants
+ *  https://www.xrite.com/service-support/understanding_illuminants
+ *  https://www.xrite.com/service-support/what_illuminants_are_available_in_xrite_hardware_and_software
+ */
 enum PhotogIlluminant {
-    D65
+    /** Tungsten-filament (incandescent) lighting */
+    A,      // 2856K
+    /** Deprecated daylight representations based on A */
+    B,      // direct @ 4874K
+    C,      // shade @ 6774K
+    /** Favoured daylight representations */
+    D50,    // 5003K
+    D55,    // ~5500K
+    D65,    // 6504K
+    D75,    // ~7500K
+    /** Hypothetical equal-energy radiator */
+    E,      // approximated by D illuminant @ 5455K
+    /** Fluorescent lighting */
+    F2,     // semi-broadband "cool-white" @ 4230K
+    F7,     // broadband @ 6500K
+    F11     // tri-band @ 4000K
 };
 
 /** Chromatically adapt RGB input from the given source illuminant to the given

--- a/src/photog/utils.h
+++ b/src/photog/utils.h
@@ -173,9 +173,9 @@ TEST_CASE ("testing mul_33_by_31") {
 
     output = photog::mul_33_by_31(a, b);
 
-            CHECK(output(0) == doctest::Approx(12.0));
-            CHECK(output(1) == doctest::Approx(30.0));
-            CHECK(output(2) == doctest::Approx(48.0));
+    CHECK(output(0) == doctest::Approx(12.0));
+    CHECK(output(1) == doctest::Approx(30.0));
+    CHECK(output(2) == doctest::Approx(48.0));
 }
 
 TEST_CASE ("testing mul_33_by_33") {
@@ -199,8 +199,7 @@ TEST_CASE ("testing mul_33_by_33") {
 
     for (int i = 0; i < output_dim; ++i) {
         for (int j = 0; j < output_dim; ++j) {
-                    CHECK(
-                    output(i, j) == doctest::Approx(expected_output[j][i]));
+            CHECK(output(i, j) == doctest::Approx(expected_output[j][i]));
         }
     }
 }
@@ -217,7 +216,7 @@ TEST_CASE ("testing div_vec_by_vec") {
     float expected_output[output_dim]{1.0, 2.0, 5.0};
 
     for (int i = 0; i < output_dim; ++i) {
-                CHECK(output(i) == doctest::Approx(expected_output[i]));
+        CHECK(output(i) == doctest::Approx(expected_output[i]));
     }
 }
 
@@ -233,8 +232,7 @@ TEST_CASE ("testing create_diagonal") {
 
     for (int i = 0; i < output_dim; ++i) {
         for (int j = 0; j < output_dim; ++j) {
-                    CHECK(
-                    output(i, j) == doctest::Approx(expected_output[j][i]));
+            CHECK(output(i, j) == doctest::Approx(expected_output[j][i]));
         }
     }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,4 +23,7 @@ doctest_discover_tests(tests)
 
 ## Copy non-source test files to test executable working directory
 ## This approach uses more disk space but prevents modification to test files
-file(COPY ${CMAKE_SOURCE_DIR}/test/images DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+add_custom_command(TARGET tests
+        COMMAND ${CMAKE_COMMAND} -E echo "Copying test images from CMAKE_SOURCE_DIR/test/images to TARGET_FILE_DIR/images")
+add_custom_command(TARGET tests
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/test/images $<TARGET_FILE_DIR:tests>/images)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -71,13 +71,13 @@ TEST_CASE ("testing photog_srgb_to_linear") {
     photog_srgb_to_linear(input, output);
 
     // 0.04045f < input(x, y, c)
-            CHECK(output(0, 0, 0) == doctest::Approx(0.423268f));
-            CHECK(output(0, 0, 1) == doctest::Approx(0.341914f));
-            CHECK(output(0, 0, 2) == doctest::Approx(0.194618f));
+    CHECK(output(0, 0, 0) == doctest::Approx(0.423268f));
+    CHECK(output(0, 0, 1) == doctest::Approx(0.341914f));
+    CHECK(output(0, 0, 2) == doctest::Approx(0.194618f));
     // input(x, y, c) <= 0.04045f
-            CHECK(output(1824, 445, 0) == doctest::Approx(0.003035f));
-            CHECK(output(1824, 445, 1) == doctest::Approx(0.003035f));
-            CHECK(output(1824, 445, 2) == doctest::Approx(0.002428f));
+    CHECK(output(1824, 445, 0) == doctest::Approx(0.003035f));
+    CHECK(output(1824, 445, 1) == doctest::Approx(0.003035f));
+    CHECK(output(1824, 445, 2) == doctest::Approx(0.002428f));
 }
 
 TEST_CASE ("testing photog_chromadapt") {
@@ -92,7 +92,7 @@ TEST_CASE ("testing photog_chromadapt") {
     photog_chromadapt(input.data(), input.width(), input.height(),
                       PhotogWorkingSpace::Srgb,
                       PhotogChromadaptMethod::Bradford,
-                      PhotogIlluminant::D65,
+                      PhotogIlluminant::D50,
                       output.data());
 
     Halide::Tools::convert_and_save_image(output, R"(images/out.jpg)");
@@ -122,7 +122,7 @@ TEST_CASE ("testing photog_chromadapt_diy") {
                           PhotogWorkingSpace::Srgb,
                           PhotogChromadaptMethod::Bradford,
                           photog::get_tristimulus(
-                                  PhotogIlluminant::D65).data(),
+                                  PhotogIlluminant::D50).data(),
                           output.data());
 
     Halide::Tools::convert_and_save_image(output, R"(images/out.jpg)");
@@ -140,13 +140,13 @@ TEST_CASE ("testing photog_rgb_to_linear") {
                          output);
 
     // 0.04045f < input(x, y, c)
-            CHECK(output(0, 0, 0) == doctest::Approx(0.431340f));
-            CHECK(output(0, 0, 1) == doctest::Approx(0.348865f));
-            CHECK(output(0, 0, 2) == doctest::Approx(0.197516f));
+    CHECK(output(0, 0, 0) == doctest::Approx(0.431340f));
+    CHECK(output(0, 0, 1) == doctest::Approx(0.348865f));
+    CHECK(output(0, 0, 2) == doctest::Approx(0.197516f));
     // input(x, y, c) <= 0.04045f
-            CHECK(output(1824, 445, 0) == doctest::Approx(0.000804f));
-            CHECK(output(1824, 445, 1) == doctest::Approx(0.000804f));
-            CHECK(output(1824, 445, 2) == doctest::Approx(0.000492f));
+    CHECK(output(1824, 445, 0) == doctest::Approx(0.000804f));
+    CHECK(output(1824, 445, 1) == doctest::Approx(0.000804f));
+    CHECK(output(1824, 445, 2) == doctest::Approx(0.000492f));
 }
 
 TEST_CASE ("testing photog_srgb_to_xyz") {
@@ -160,13 +160,13 @@ TEST_CASE ("testing photog_srgb_to_xyz") {
     photog_srgb_to_xyz(input, output);
 
     // 0.04045f < input(x, y, c)
-            CHECK(output(0, 0, 0) == doctest::Approx(0.331956f));
-            CHECK(output(0, 0, 1) == doctest::Approx(0.348585f));
-            CHECK(output(0, 0, 2) == doctest::Approx(0.233883f));
+    CHECK(output(0, 0, 0) == doctest::Approx(0.331956f));
+    CHECK(output(0, 0, 1) == doctest::Approx(0.348585f));
+    CHECK(output(0, 0, 2) == doctest::Approx(0.233883f));
     // input(x, y, c) <= 0.04045f
-            CHECK(output(1824, 445, 0) == doctest::Approx(0.002775f));
-            CHECK(output(1824, 445, 1) == doctest::Approx(0.002991f));
-            CHECK(output(1824, 445, 2) == doctest::Approx(0.002728f));
+    CHECK(output(1824, 445, 0) == doctest::Approx(0.002775f));
+    CHECK(output(1824, 445, 1) == doctest::Approx(0.002991f));
+    CHECK(output(1824, 445, 2) == doctest::Approx(0.002728f));
 }
 
 TEST_CASE ("testing photog_rgb_to_xyz") {
@@ -183,13 +183,13 @@ TEST_CASE ("testing photog_rgb_to_xyz") {
                       output);
 
     // 0.04045f < input(x, y, c)
-            CHECK(output(0, 0, 0) == doctest::Approx(0.338294f));
-            CHECK(output(0, 0, 1) == doctest::Approx(0.355482f));
-            CHECK(output(0, 0, 2) == doctest::Approx(0.237622f));
+    CHECK(output(0, 0, 0) == doctest::Approx(0.338294f));
+    CHECK(output(0, 0, 1) == doctest::Approx(0.355482f));
+    CHECK(output(0, 0, 2) == doctest::Approx(0.237622f));
     // input(x, y, c) <= 0.04045f
-            CHECK(output(1824, 445, 0) == doctest::Approx(0.000708f));
-            CHECK(output(1824, 445, 1) == doctest::Approx(0.000782f));
-            CHECK(output(1824, 445, 2) == doctest::Approx(0.000580f));
+    CHECK(output(1824, 445, 0) == doctest::Approx(0.000708f));
+    CHECK(output(1824, 445, 1) == doctest::Approx(0.000782f));
+    CHECK(output(1824, 445, 2) == doctest::Approx(0.000580f));
 }
 
 TEST_CASE ("testing photog_linear_to_srgb") {
@@ -209,13 +209,13 @@ TEST_CASE ("testing photog_linear_to_srgb") {
     photog_linear_to_srgb(linear, output);
 
     // 0.0031308f < input(x, y, c)
-            CHECK(output(0, 0, 0) == doctest::Approx(input(0, 0, 0)));
-            CHECK(output(0, 0, 1) == doctest::Approx(input(0, 0, 1)));
-            CHECK(output(0, 0, 2) == doctest::Approx(input(0, 0, 2)));
+    CHECK(output(0, 0, 0) == doctest::Approx(input(0, 0, 0)));
+    CHECK(output(0, 0, 1) == doctest::Approx(input(0, 0, 1)));
+    CHECK(output(0, 0, 2) == doctest::Approx(input(0, 0, 2)));
     // input(x, y, c) <= 0.0031308f
-            CHECK(output(4550, 711, 0) == doctest::Approx(input(4550, 711, 0)));
-            CHECK(output(4550, 711, 1) == doctest::Approx(input(4550, 711, 1)));
-            CHECK(output(4550, 711, 2) == doctest::Approx(input(4550, 711, 2)));
+    CHECK(output(4550, 711, 0) == doctest::Approx(input(4550, 711, 0)));
+    CHECK(output(4550, 711, 1) == doctest::Approx(input(4550, 711, 1)));
+    CHECK(output(4550, 711, 2) == doctest::Approx(input(4550, 711, 2)));
 }
 
 TEST_CASE ("testing photog_linear_to_rgb") {
@@ -238,13 +238,13 @@ TEST_CASE ("testing photog_linear_to_rgb") {
                          output);
 
     // 0.0031308f < input(x, y, c)
-            CHECK(output(0, 0, 0) == doctest::Approx(input(0, 0, 0)));
-            CHECK(output(0, 0, 1) == doctest::Approx(input(0, 0, 1)));
-            CHECK(output(0, 0, 2) == doctest::Approx(input(0, 0, 2)));
+    CHECK(output(0, 0, 0) == doctest::Approx(input(0, 0, 0)));
+    CHECK(output(0, 0, 1) == doctest::Approx(input(0, 0, 1)));
+    CHECK(output(0, 0, 2) == doctest::Approx(input(0, 0, 2)));
     // input(x, y, c) <= 0.0031308f
-            CHECK(output(4550, 711, 0) == doctest::Approx(input(4550, 711, 0)));
-            CHECK(output(4550, 711, 1) == doctest::Approx(input(4550, 711, 1)));
-            CHECK(output(4550, 711, 2) == doctest::Approx(input(4550, 711, 2)));
+    CHECK(output(4550, 711, 0) == doctest::Approx(input(4550, 711, 0)));
+    CHECK(output(4550, 711, 1) == doctest::Approx(input(4550, 711, 1)));
+    CHECK(output(4550, 711, 2) == doctest::Approx(input(4550, 711, 2)));
 }
 
 TEST_CASE ("testing photog_xyz_to_srgb") {
@@ -264,13 +264,13 @@ TEST_CASE ("testing photog_xyz_to_srgb") {
     photog_xyz_to_srgb(xyz, output);
 
     // 0.0031308f < input(x, y, c)
-            CHECK(output(0, 0, 0) == doctest::Approx(input(0, 0, 0)));
-            CHECK(output(0, 0, 1) == doctest::Approx(input(0, 0, 1)));
-            CHECK(output(0, 0, 2) == doctest::Approx(input(0, 0, 2)));
+    CHECK(output(0, 0, 0) == doctest::Approx(input(0, 0, 0)));
+    CHECK(output(0, 0, 1) == doctest::Approx(input(0, 0, 1)));
+    CHECK(output(0, 0, 2) == doctest::Approx(input(0, 0, 2)));
     // input(x, y, c) <= 0.0031308f
-            CHECK(output(4550, 711, 0) == doctest::Approx(input(4550, 711, 0)));
-            CHECK(output(4550, 711, 1) == doctest::Approx(input(4550, 711, 1)));
-            CHECK(output(4550, 711, 2) == doctest::Approx(input(4550, 711, 2)));
+    CHECK(output(4550, 711, 0) == doctest::Approx(input(4550, 711, 0)));
+    CHECK(output(4550, 711, 1) == doctest::Approx(input(4550, 711, 1)));
+    CHECK(output(4550, 711, 2) == doctest::Approx(input(4550, 711, 2)));
 }
 
 TEST_CASE ("testing photog_xyz_to_rgb") {
@@ -296,13 +296,13 @@ TEST_CASE ("testing photog_xyz_to_rgb") {
                       output);
 
     // 0.0031308f < input(x, y, c)
-            CHECK(output(0, 0, 0) == doctest::Approx(input(0, 0, 0)));
-            CHECK(output(0, 0, 1) == doctest::Approx(input(0, 0, 1)));
-            CHECK(output(0, 0, 2) == doctest::Approx(input(0, 0, 2)));
+    CHECK(output(0, 0, 0) == doctest::Approx(input(0, 0, 0)));
+    CHECK(output(0, 0, 1) == doctest::Approx(input(0, 0, 1)));
+    CHECK(output(0, 0, 2) == doctest::Approx(input(0, 0, 2)));
     // input(x, y, c) <= 0.0031308f
-            CHECK(output(4550, 711, 0) == doctest::Approx(input(4550, 711, 0)));
-            CHECK(output(4550, 711, 1) == doctest::Approx(input(4550, 711, 1)));
-            CHECK(output(4550, 711, 2) == doctest::Approx(input(4550, 711, 2)));
+    CHECK(output(4550, 711, 0) == doctest::Approx(input(4550, 711, 0)));
+    CHECK(output(4550, 711, 1) == doctest::Approx(input(4550, 711, 1)));
+    CHECK(output(4550, 711, 2) == doctest::Approx(input(4550, 711, 2)));
 }
 
 TEST_CASE ("testing photog_average") {
@@ -343,7 +343,7 @@ TEST_CASE ("testing photog_average") {
         ++i;
     }
 
-            CHECK(averages[0] == doctest::Approx(output(0)));
-            CHECK(averages[1] == doctest::Approx(output(1)));
-            CHECK(averages[2] == doctest::Approx(output(2)));
+    CHECK(averages[0] == doctest::Approx(output(0)));
+    CHECK(averages[1] == doctest::Approx(output(1)));
+    CHECK(averages[2] == doctest::Approx(output(2)));
 }


### PR DESCRIPTION
    Add more standard illuminants to the project alongside their
    respective tristimulus values.

    The following changes are not related to illuminants but were
    required during testing:
     - Modify the test image copying command to work on Windows. The
       Visual Studio generators save project output to subfolders
       named for the build type instead of directly to the CMake
       binary directory.
     - Reformat files containing doctest checks.