### PR TITLE
Update to Halide 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.28)
 project(photog
         VERSION 0.0.1) # Provides access to photog_VERSION and its variants
 
@@ -15,7 +15,6 @@ FetchContent_Declare(doctest
         GIT_TAG v2.4.11)
 FetchContent_MakeAvailable(doctest)
 list(APPEND CMAKE_MODULE_PATH ${doctest_SOURCE_DIR}/scripts/cmake)
-find_package(doctest)
 
 if (APPLE)
     # Prevents latching onto JPEG/PNG libraries vendored within frameworks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,34 @@ project(photog
         VERSION 0.0.1) # Provides access to photog_VERSION and its variants
 
 include(CTest)
+include(FetchContent)
 
 # Setup language settings
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-# Find doctest
-find_package(doctest 2 REQUIRED)
+FetchContent_Declare(doctest
+        GIT_REPOSITORY https://github.com/doctest/doctest.git
+        GIT_TAG v2.4.11)
+FetchContent_MakeAvailable(doctest)
+list(APPEND CMAKE_MODULE_PATH ${doctest_SOURCE_DIR}/scripts/cmake)
+find_package(doctest)
 
-# Find Halide
 if (APPLE)
     # Prevents latching onto JPEG/PNG libraries vendored within frameworks
     set(CMAKE_FIND_FRAMEWORK LAST)
+
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+        FetchContent_Declare(halide
+                URL https://github.com/halide/Halide/releases/download/v12.0.0/Halide-12.0.0-x86-64-osx-b5a34c33fa92fdaed81aee909b07936d96475b92.tar.gz)
+    else ()
+        FetchContent_Declare(halide
+                URL https://github.com/halide/Halide/releases/download/v12.0.0/Halide-12.0.0-arm-64-osx-b5a34c33fa92fdaed81aee909b07936d96475b92.tar.gz)
+    endif ()
 endif ()
+FetchContent_MakeAvailable(halide)
+list(APPEND CMAKE_PREFIX_PATH ${halide_SOURCE_DIR})
 find_package(Halide 12 REQUIRED)
 
 # Global settings
@@ -49,10 +63,6 @@ endif ()
 message(STATUS "photog image layout:             ${photog_IMAGE_LAYOUT}")
 message(STATUS "photog image width estimate:     ${photog_IMAGE_WIDTH_ESTIMATE}px")
 message(STATUS "photog image height estimate:    ${photog_IMAGE_HEIGHT_ESTIMATE}px")
-# TODO: Add CMakePresets.json file.
-# TODO: Can we provide a useful message if a setting is not valid?
-# TODO: Add CMake function for loading CLI/environment arguments.
-# TODO: Allow user to specify variables from their project that includes photog.
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,15 +22,15 @@ if (APPLE)
 
     if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
         FetchContent_Declare(halide
-                URL https://github.com/halide/Halide/releases/download/v12.0.0/Halide-12.0.0-x86-64-osx-b5a34c33fa92fdaed81aee909b07936d96475b92.tar.gz)
+                URL https://github.com/halide/Halide/releases/download/v17.0.1/Halide-17.0.1-x86-64-osx-52541176253e74467dabc42eeee63d9a62c199f6.tar.gz)
     else ()
         FetchContent_Declare(halide
-                URL https://github.com/halide/Halide/releases/download/v12.0.0/Halide-12.0.0-arm-64-osx-b5a34c33fa92fdaed81aee909b07936d96475b92.tar.gz)
+                URL https://github.com/halide/Halide/releases/download/v17.0.1/Halide-17.0.1-arm-64-osx-52541176253e74467dabc42eeee63d9a62c199f6.tar.gz)
     endif ()
 endif ()
 FetchContent_MakeAvailable(halide)
 list(APPEND CMAKE_PREFIX_PATH ${halide_SOURCE_DIR})
-find_package(Halide 12 REQUIRED)
+find_package(Halide 17 REQUIRED)
 
 # Global settings
 ## Extent estimates for generators

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 project(photog
-        VERSION 0.0.1) # Provides access to photog_VERSION and its variants
+        VERSION 0.1.0) # Provides access to photog_VERSION and its variants
 
 include(CTest)
 include(FetchContent)

--- a/src/photog/CMakeLists.txt
+++ b/src/photog/CMakeLists.txt
@@ -52,7 +52,7 @@ foreach (color_halide_library IN LISTS color_halide_libraries)
         add_halide_library(${color_halide_library} FROM color_generators
                 GENERATOR ${color_halide_library}
                 AUTOSCHEDULER Halide::Adams2019
-                PARAMS auto_schedule=true layout=${photog_IMAGE_LAYOUT}
+                PARAMS layout=${photog_IMAGE_LAYOUT}
                 SCHEDULE ${color_halide_library}_schedule
                 HEADER ${color_halide_library}_header)
     else ()
@@ -60,7 +60,7 @@ foreach (color_halide_library IN LISTS color_halide_libraries)
                 GENERATOR ${color_halide_library}
                 USE_RUNTIME ${shared_halide_runtime}
                 AUTOSCHEDULER Halide::Adams2019
-                PARAMS auto_schedule=true layout=${photog_IMAGE_LAYOUT}
+                PARAMS layout=${photog_IMAGE_LAYOUT}
                 SCHEDULE ${color_halide_library}_schedule
                 HEADER ${color_halide_library}_header)
     endif ()

--- a/src/photog/generator.h
+++ b/src/photog/generator.h
@@ -30,7 +30,7 @@ namespace photog {
          * when auto_schedule/manual_schedule respectively are set to true. Auto-scheduling is
          * prioritized over manual schedules.*/
         void schedule() {
-            if (this->auto_schedule) {
+            if (this->using_autoscheduler()) {
                 schedule_auto();
             } else if (manual_schedule) {
                 schedule_manual();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,8 @@
-# Find doctest
-find_package(doctest 2 REQUIRED)
-
-# Find JPEG and PNG libraries
 find_package(JPEG REQUIRED)
 find_package(PNG REQUIRED)
 
-# Test executable
 add_executable(tests tests.cpp)
+target_include_directories(tests PRIVATE ${PNG_INCLUDE_DIRS})
 target_link_libraries(tests
         PRIVATE
         color

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(tests
         ${PNG_LIBRARIES})
 
 include(doctest) # enables doctest_discover_tests
-
 doctest_discover_tests(tests)
 
 ## Copy non-source test files to test executable working directory


### PR DESCRIPTION
Update the project to use Halide 17. This required minimal changes to auto-scheduling configuration.

Switch to fetching Halide and doctest from their respective repositories. This makes it easier to get started with photog. The only remaining packages that need manual setup are libjpeg-turbo and libpng. We can likely make those easier to fetch by switching to vcpkg.